### PR TITLE
Move face direction change - for vertical camera rotation fix

### DIFF
--- a/Player/Moves/Run.gd
+++ b/Player/Moves/Run.gd
@@ -25,7 +25,7 @@ func update(input : InputPackage, delta : float):
 func rotate_velocity(input : InputPackage, delta : float):
 	var input_direction = (humanoid.camera_mount.basis * Vector3(-input.input_direction.x, 0, -input.input_direction.y)).normalized()
 	var face_direction = humanoid.basis.z
-	var angle = face_direction.signed_angle_to(input_direction, Vector3.UP)
+	var angle = face_direction.signed_angle_to(input_direction.slide(Vector3.UP), Vector3.UP) 
 	if abs(angle) >= ANGULAR_SPEED * delta:
 		humanoid.velocity = face_direction.rotated(Vector3.UP, sign(angle) * ANGULAR_SPEED * delta) * TURN_SPEED
 	else:

--- a/Player/Moves/Sprint.gd
+++ b/Player/Moves/Sprint.gd
@@ -32,7 +32,7 @@ func update(input : InputPackage, delta : float):
 func rotate_velocity(input : InputPackage, delta : float):
 	var input_direction = (humanoid.camera_mount.basis * Vector3(-input.input_direction.x, 0, -input.input_direction.y)).normalized()
 	var face_direction = humanoid.basis.z
-	var angle = face_direction.signed_angle_to(input_direction, Vector3.UP)
+	var angle = face_direction.signed_angle_to(input_direction.slide(Vector3.UP), Vector3.UP) 
 	if abs(angle) >= ANGULAR_SPEED * delta:
 		humanoid.velocity = face_direction.rotated(Vector3.UP, sign(angle) * ANGULAR_SPEED * delta) * TURN_SPEED
 	else:


### PR DESCRIPTION
This is a relatively small change, but it fixes an interesting "issue" if you allow the camera to be rotated vertically (up and down with the mouse). Without this, and if the camera is allowed to be rotated vertically, the character will start to jitter and slow down while they run or sprint. 

This is because the angle of the camera has now changed vertically, so the vector is in a different place; the signed_angle_to function does not properly account for this, and thus, the humanoid velocity gets wonky as a result (animator speed scale is also affected by this, but it is not the main culprit).

By sliding the input_direction onto the y-axis (Vector3.UP), we project the camera vector onto the same axis associated with the character's face direction that we are trying to get an angle to (on the Vector3.UP axis). So both vectors end up being on the same axis, and thus, signed_angle_to gives the correct result again.

Technically, this is optional, but if someone decides to use the current project as a base for creating say something like an fps (which requires vertical camera rotation), then this change would alleviate some potential future head aches. Otherwise, this change does not have an effect on the current camera rotation scheme (except for maybe an additional negligible performance cost). 